### PR TITLE
using Metaclass for recording schema fields, with other minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 # Komodoproject
 *.komodoproject
+
+# ctags
+tags

--- a/arango_orm/collections.py
+++ b/arango_orm/collections.py
@@ -1,3 +1,4 @@
+from six import with_metaclass
 from marshmallow import (
     Schema, fields, ValidationError
 )

--- a/arango_orm/collections.py
+++ b/arango_orm/collections.py
@@ -11,7 +11,25 @@ class MemberExistsException(Exception):
     pass
 
 
-class CollectionBase(with_metaclass(ABCMeta)):
+class CollectionMeta(ABCMeta):
+    def __new__(cls, name, bases, attrs):
+        super_new = super(CollectionMeta, cls).__new__
+
+        new_fields = {}
+        for obj_name, obj in attrs.items():
+            if isinstance(obj, fields.Field):
+                # add to schema fields
+                new_fields[obj_name] = attrs.get(obj_name)
+
+        for k in new_fields:
+            attrs.pop(k)
+
+        new_class = super_new(cls, name, bases, attrs)
+        new_class._fields = dict(getattr(cls, '_fields', {}), **new_fields)
+        return new_class
+
+
+class CollectionBase(with_metaclass(CollectionMeta)):
     "Base class for Collections, Nodes and Links"
 
     _key_field = None
@@ -23,29 +41,14 @@ class CollectionBase(with_metaclass(ABCMeta)):
         pass
 
     @classmethod
-    def schema(cls):
-
-        fields_dict = {}
-
-        for attr_name in dir(cls):
-            attr_obj = getattr(cls, attr_name)
-            if not callable(attr_obj) and isinstance(attr_obj, fields.Field):
-                # add to schema fields
-                fields_dict[attr_name] = attr_obj
-
+    def schema(cls, *args, **kwargs):
         SchemaClass = type(
             cls.__name__ + 'Schema',
             (Schema, ),
-            fields_dict
+            cls._fields.copy()
         )
 
-        return SchemaClass()
-
-    def remove_schema_fields(self):
-        for attr_name in dir(self):
-            attr_obj = getattr(self, attr_name)
-            if not callable(attr_obj) and isinstance(attr_obj, fields.Field):
-                setattr(self, attr_name, None)
+        return SchemaClass(*args, **kwargs)
 
 
 class Collection(CollectionBase):
@@ -54,7 +57,8 @@ class Collection(CollectionBase):
 
     _safe_list = [
         '__collection__', '_safe_list', '_relations', '_id', '_index',
-        '_collection_config', '_post_process', '_pre_process', '_fields_info'
+        '_collection_config', '_post_process', '_pre_process', '_fields_info',
+        '_fields'
     ]
 
     def __init__(self, collection_name=None, **kwargs):
@@ -65,6 +69,10 @@ class Collection(CollectionBase):
         if '_key' not in kwargs:
             self._key = None
 
+        for k in self._fields:
+            setattr(self, k, kwargs.pop(k, None))
+
+        # FIXME: shall we ignore attrs not defined in schema
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -84,7 +92,6 @@ class Collection(CollectionBase):
     @classmethod
     def _load(cls, in_dict, instance=None, db=None):
         "Create object from given dict"
-
         if instance:
             in_dict = dict(instance._dump(), **in_dict)
 
@@ -126,7 +133,6 @@ class Collection(CollectionBase):
         "Dump all object attributes into a dict"
 
         schema = self.schema
-        self.remove_schema_fields()
         data, errors = schema().dump(self)
 
         if errors:
@@ -161,7 +167,7 @@ class Relation(Collection):
 
     _safe_list = [
         '__collection__', '_safe_list', '_id', '_collections_from', '_collections_to',
-        '_object_from', '_object_to', '_index', '_collection_config'
+        '_object_from', '_object_to', '_index', '_collection_config', '_fields'
     ]
 
     def __init__(self, collection_name=None, **kwargs):

--- a/tests/data.py
+++ b/tests/data.py
@@ -2,14 +2,34 @@ from arango_orm.fields import String, Date, Integer, Boolean
 from arango_orm import Collection, Relation, Graph, GraphConnection
 
 
+class lazy_property(object):
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, instance, cls):
+        value = self.fget(instance)
+        setattr(instance, self.fget.__name__, value)
+        return value
+
+
 class Person(Collection):
 
     __collection__ = 'persons'
     _index = [{'type': 'hash', 'unique': False, 'fields': ['name']}]
+    _allow_extra_fields = False  # prevent extra properties from saving into DB
 
     _key = String(required=True)
     name = String(required=True, allow_none=False)
+    age = Integer(missing=None)
     dob = Date()
+
+    @property
+    def is_adult(self):
+        return self.age and self.age >= 18
+
+    @lazy_property
+    def lazy_is_adult(self):
+        return self.age and self.age >= 18
 
     def __str__(self):
         return "<Person(" + self.name + ")>"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -64,7 +64,7 @@ class TestDatabase(TestBase):
 
         db = self._get_db_obj()
 
-        p = Person(name='test', _key='12312', dob=date(year=2016, month=9, day=12))
+        p = Person(name='test', _key='12312', age=18, dob=date(year=2016, month=9, day=12))
         db.add(p)
 
     def test_06_delete_records(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34, py35, py36, pypy
+
+[testenv]
+commands = nosetests tests
+deps =
+    nose


### PR DESCRIPTION
- CollectionMeta for recording schema fields at class declaration setp
- resolves https://github.com/threatify/arango-orm/issues/21
- tested the changes under py27, py34, py35, py36, pypy using tox

---

using tox to run test suite:

```
pip install tox
tox
```