### PR TITLE
fix condition for setting entity._key after added to db

### DIFF
--- a/arango_orm/database.py
+++ b/arango_orm/database.py
@@ -76,7 +76,7 @@ class Database(ArangoDatabase):
         collection = self._db.collection(entity.__collection__)
         setattr(entity, '_db', self)
         res = collection.insert(entity._dump())
-        if not hasattr(entity, '_key') and '_key' in res:
+        if not getattr(entity, '_key', None) and '_key' in res:
             setattr(entity, '_key', res['_key'])
 
         return res
@@ -185,4 +185,3 @@ class Database(ArangoDatabase):
                 graph.delete_vertex_collection(col, purge=True)
 
         self._db.delete_graph(graph_object.__graph__)
-


### PR DESCRIPTION
See:
https://github.com/threatify/arango-orm/blame/40a4e75f8e8ef7dd7fee921f07372fb0e7bad161/arango_orm/collections.py#L65

The two lines set `_key=None` while initialize a new collection object.