### PR TITLE
Dirty checking support when doing update

### DIFF
--- a/arango_orm/collections.py
+++ b/arango_orm/collections.py
@@ -104,24 +104,24 @@ class Collection(CollectionBase):
     def __getattribute__(self, item):
 
         # print("__getatttribute__ called!")
-        if item not in super().__getattribute__('_refs'):  # pylint: disable=E1101
-            return super().__getattribute__(item)  # pylint: disable=E1101
+        if item not in super(Collection, self).__getattribute__('_refs'):  # pylint: disable=E1101
+            return super(Collection, self).__getattribute__(item)  # pylint: disable=E1101
 
-        if item not in super().__getattribute__('_refs_vals'):  # pylint: disable=E1101
+        if item not in super(Collection, self).__getattribute__('_refs_vals'):  # pylint: disable=E1101
 
             # print("trying to load ref val")
             # pdb.set_trace()
             if (hasattr(self, '_db') is False or
-                    super().__getattribute__('_db') is None):  # pylint: disable=E1101
+                    super(Collection, self).__getattribute__('_db') is None):  # pylint: disable=E1101
                 raise DetachedInstanceError()
 
-            db = super().__getattribute__('_db')  # pylint: disable=E1101
-            ref_class = super().__getattribute__('_refs')[item]  # pylint: disable=E1101
+            db = super(Collection, self).__getattribute__('_db')  # pylint: disable=E1101
+            ref_class = super(Collection, self).__getattribute__('_refs')[item]  # pylint: disable=E1101
 
             r_val = None
             if '_key' == ref_class.target_field:
                 r_val = db.query(ref_class.col_class).by_key(
-                    super().__getattribute__(ref_class.field))  # pylint: disable=E1101
+                    super(Collection, self).__getattribute__(ref_class.field))  # pylint: disable=E1101
 
                 if ref_class.uselist is True:
                     r_val = [r_val, ]
@@ -130,22 +130,22 @@ class Collection(CollectionBase):
                 if ref_class.uselist is False:
                     r_val = db.query(ref_class.col_class).filter(
                         ref_class.target_field + "==@val",
-                        val=super().__getattribute__(ref_class.field)  # pylint: disable=E1101
+                        val=super(Collection, self).__getattribute__(ref_class.field)  # pylint: disable=E1101
                         ).first()
 
                 else:
                     # TODO: Handle ref_class.order_by if present
                     r_val = db.query(ref_class.col_class).filter(
                         ref_class.target_field + "==@val",
-                        val=super().__getattribute__(ref_class.field)  # pylint: disable=E1101
+                        val=super(Collection, self).__getattribute__(ref_class.field)  # pylint: disable=E1101
                         ).all()
 
             if ref_class.cache is True:
-                super().__getattribute__('_refs_vals')[item] = r_val  # pylint: disable=E1101
+                super(Collection, self).__getattribute__('_refs_vals')[item] = r_val  # pylint: disable=E1101
             else:
                 return r_val
 
-        return super().__getattribute__('_refs_vals')[item]  # pylint: disable=E1101
+        return super(Collection, self).__getattribute__('_refs_vals')[item]  # pylint: disable=E1101
 
     @classmethod
     def _load(cls, in_dict, instance=None, db=None):

--- a/arango_orm/query.py
+++ b/arango_orm/query.py
@@ -72,6 +72,8 @@ class Query(object):
             return self
 
         condition = ' AND '.join(['$REC.{0}==@{0}'.format(k) for k in kwargs])
+        if len(kwargs) > 1:
+            condition = '({0})'.format(condition)
 
         return self.filter(condition, _or=_or, prepend_rec_name=False,
                            rec_name_placeholder='$REC', **kwargs)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -62,3 +62,8 @@ class TestBase(unittest.TestCase):
                 raise exp_to_raise
 
         return True
+
+    def assert_has_same_items(self, left, right, exp_to_raise=AssertionError):
+        if not set(left) == set(right):
+            raise exp_to_raise
+        return True

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -125,3 +125,13 @@ class TestCollection(TestBase):
         assert p.name == 'test'
         assert np.name == 'Wonder'
         assert np._key == '12312'
+
+    def test_10_dirty_fields(self):
+        p1 = Person(name='test', _key='12312', dob=date(year=2016, month=9, day=12))
+        p2 = Person._load({'_key': '37405-4564665-7', 'dob': '2016-09-12', 'name': 'Kashif Iftikhar'})
+        self.assert_has_same_items(p1._dirty, ['name', '_key', 'dob', 'age', 'is_staff'])
+        self.assert_has_same_items(p2._dirty, ['name', '_key', 'dob', 'age', 'is_staff'])
+
+        p1._dirty.clear()
+        p1.name = 'test'  # change name, even if the same as before!
+        self.assert_has_same_items(p1._dirty, ['name'])

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,12 +1,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import sys
 from datetime import date
 from arango_orm.event import dispatch, listen, listens_for
 from arango_orm import Collection
-try:
+if sys.version >= '3.6':
+    # Since assert_called_once is wew in version 3.6
     from unittest.mock import create_autospec, Mock
-except ImportError:
+else:
     from mock import create_autospec, Mock
 
 from . import TestBase


### PR DESCRIPTION
Dirty checking support when doing update.

```python
p_ref1 = db.query(Person).by_key("12312")
p_ref2 = db.query(Person).by_key("12312")

p_ref1.name = 'NB-1'
p_ref1.age = 98
p_ref2.age = 99

db.update(p_ref1)
db.update(p_ref2, only_dirty=True)

fresh = db.query(Person).by_key("12312")
assert fresh.name == 'NB-1'
assert fresh.age == 99
```

```shell
$ tox
  py27: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  pypy: commands succeeded
  congratulations :)
```