### PR TITLE
Support fetching only partial fields while query collections

### DIFF
--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -35,6 +35,14 @@ class TestCollection(TestBase):
         assert '12312' == d['_key']
         assert '2016-09-12' == d['dob']
 
+    def test_03_01_object_dump_only(self):
+
+        p = Person(name='test', _key='12312', dob=date(year=2016, month=9, day=12))
+        only_fields = ['_key', 'name']
+        d = p._dump(only=only_fields)
+
+        self.assert_has_same_items(only_fields, d.keys())
+
     def test_04_object_partial_fields_and_dump(self):
 
         p = Person(name='test', _key='12312')

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -202,6 +202,16 @@ class TestQuery(TestBase):
         assert "Toyota" == records[1].make
         assert "Corolla" == records[1].model
 
+    def test_13_01_fetch_partial_fields(self):
+
+        db = self._get_db_obj()
+
+        r0 = db.query(Car).limit(1).returns('make', 'model', 'year').all()[0]
+        r1 = db.query(Car).limit(1).returns('make', 'model', 'year').first()
+
+        assert r0.owner_key is None
+        assert r1.owner_key is None
+
     def test_14_update_filtered_records(self):
 
         db = self._get_db_obj()


### PR DESCRIPTION
```python
>>> c = db.query(Case).limit(2).first()
>>> c._dump()
{'_key': '221752334',
 'tags': ['test'],
 'title': 'test123',
 'tracker': 'Wonder'}

>>> c = db.query(Case).limit(2).returns('_key', 'title').first()
>>> c.tracker
None
>>> c._dump()
{'_key': '221752334', 'title': 'test123'}
```