### PR TITLE
Instanciate embedded objects in schema upon load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:alpine
+
+RUN mkdir /code
+COPY . /code
+WORKDIR /code
+
+# Install the project requirements
+RUN pip install .
+RUN pip install pytest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2.1'
+
+services:
+  arango_orm:
+    build: .
+    ports:
+            - "8000:8000"
+    volumes:
+      - .:/code
+    env_file:
+      - .env
+    depends_on:
+      - arangodb
+
+  arangodb:
+    image: arangodb:3.6.2
+    ports:
+            - "8560:8529"
+    expose:
+            - "8529"
+    volumes:
+      - /var/lib/arangodb3
+      - ./db/database-dump:/docker-entrypoint-initdb.d
+      - ./db/initial-data:/initial-data
+      - ./db/various_dumps:/db-dump
+    environment:
+      ARANGO_ROOT_PASSWORD: password

--- a/getting-started.rst
+++ b/getting-started.rst
@@ -1,0 +1,19 @@
+Getting started contributing to Arango ORM
+==========================================
+Docker
+------
+To initially get started with docker, ensure you have docker(https://www.docker.com/) installed.
+
+Once successfully installed and setup, run
+
+.. code-block:: shell-session
+docker-compose --build
+
+This will build the development enviroment, spinning up
+ - an Arango instance (arango)
+ - a test image (arango_orm)
+
+To run tests from there, run
+
+.. code-block:: shell-session
+docker-compose run arango_orm pytest tests/

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from arango_orm.fields import String, Date, Integer, Boolean
+from arango_orm.fields import String, Date, Integer, Boolean, List, Nested, Number
 from arango_orm import Collection, Relation, Graph, GraphConnection
 from arango_orm.references import relationship, graph_relationship
 
@@ -7,6 +7,16 @@ from .utils import lazy_property
 
 
 class Person(Collection):
+
+    class Hobby(Collection):
+
+        class Equipment(Collection):
+            name = String(required=False, allow_none=True)
+            price = Number(required=False, allow_none=True)
+
+        name = String(required=False, allow_none=True)
+        type = String(required=True, allow_none=False)
+        equipment = List(Nested(Equipment.schema()), required=False, allow_none=True, default=None)
 
     __collection__ = "persons"
     _allow_extra_fields = False
@@ -18,7 +28,8 @@ class Person(Collection):
     age = Integer(allow_none=True, missing=None)
     dob = Date(allow_none=True, missing=None)
     is_staff = Boolean(default=False)
-
+    favorite_hobby = Nested(Hobby.schema(), required=False, allow_none=True, default=None)
+    hobby = List(Nested(Hobby.schema()), required=False, allow_none=True, default=None)
     cars = relationship(__name__ + ".Car", "_key", target_field="owner_key")
 
     @property


### PR DESCRIPTION
Currently embedded objects in schemas, using Nested field are returned as dictionaries,
rather then as their object equivalent.
This change instanciates all objects upon load using the @post_load decorator upon schemas,
automatically instanciating both top level objects and their embedded counterparts.


Add docker-compose and pytest for quick, consistent setup of application and tests for
contributors to package.
Added getting-started to explain how to get started on how to run tests for package.

