### PR TITLE
Bulk Create and Bulk Update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,32 @@ ___________________
     db.query(Student).delete()
 
 
+
+Bulk Create Records
+_______________________
+
+.. code-block:: python
+
+    s1 = Student(name='test1', _key='12345', dob=date(year=2016, month=9, day=12))
+    s2 = Student(name='test2', _key='22346', dob=date(year=2015, month=9, day=12)
+    car1 = Car(make="Honda", model="Fiat", year=2010)
+    car2 = Car(make="Honda", model="Skoda", year=2015)
+
+    db.bulk_add(entity_list=[p_ref_10, p_ref_11, car1, car2])
+
+
+Bulk Update Records
+_______________________
+
+.. code-block:: python
+
+    p_ref1 = db.query(Person).by_key("12312")
+    p_ref2 = db.query(Person).by_key("12345")
+    p_ref1.name = "Bruce"
+    p_ref2.name = "Eliza"
+    db.bulk_update(entity_list=[p_ref1, p_ref2])
+
+
 Query Using AQL
 ________________
 

--- a/arango_orm/query.py
+++ b/arango_orm/query.py
@@ -207,8 +207,8 @@ class Query(object):
             % update_clause
             + options
         )
-        log.critical(aql)
-        log.critical(self._bind_vars)
+        log.info(aql)
+        log.info(self._bind_vars)
 
         return self._db.aql.execute(aql, bind_vars=self._bind_vars)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,6 @@ import os
 import unittest
 import logging
 
-import pytest
 from arango import ArangoClient
 
 from arango_orm.database import Database
@@ -10,18 +9,6 @@ from arango_orm.database import Database
 from .utils import lazy_property
 
 log = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="session", autouse=True)
-def setup_database_test(request):
-    username = os.environ.get('ARANGO_USERNAME', "test")
-    password = os.environ.get('ARANGO_PASSWORD', "test")
-    arango_ip = os.environ.get('ARANGO_IP', "http://arangodb:8529")
-    database_name = os.environ.get('ARANGO_DATABASE', "test")
-
-    sys_db = ArangoClient(hosts=arango_ip).db('_system', username=username, password=password)
-    sys_db.create_database(database_name)
-    yield
 
 
 class TestBase(unittest.TestCase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import logging
+import os
+
+import pytest
+from arango import ArangoClient
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database_test(request):
+    username = os.environ.get('ARANGO_USERNAME', "test")
+    password = os.environ.get('ARANGO_PASSWORD', "test")
+    arango_ip = os.environ.get('ARANGO_IP', "http://arangodb:8529")
+    database_name = os.environ.get('ARANGO_DATABASE', "test")
+
+    sys_db = ArangoClient(hosts=arango_ip).db('_system', username=username, password=password)
+    sys_db.create_database(database_name)
+    yield


### PR DESCRIPTION
Implement bulk import and update capabilities to avoid numerous database calls
when numerous objects require to be created at once.

Supports uploading multiple different classes in unison.
The resource list response is in same order as sent, allowing for attaching attribute
_key to response of created objects.

Plus some minor cleanups around logging and running tests first time