### PR TITLE
Add full count support to the Query

### DIFF
--- a/arango_orm/query.py
+++ b/arango_orm/query.py
@@ -41,6 +41,16 @@ class Query(object):
 
         return next(results)
 
+    def full_count(self):
+        "Return collection full count"
+
+        aql = self._make_aql()
+
+        aql += "\n RETURN rec"
+
+        cursor = self._db.aql.execute(aql, bind_vars=self._bind_vars, full_count=True)
+        return cursor.statistics()['fullCount']
+
     def by_key(self, key, **kwargs):
         "Return a single document using it's key"
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -266,3 +266,11 @@ class TestQuery(TestBase):
         db.query(Car).delete()
 
         assert 0 == db.query(Car).count()
+
+    def test_19_get_full_count(self):
+
+        db = self._get_db_obj()
+
+        count_1 = db.query(Person).limit(1).full_count()
+
+        assert count_1 == 2


### PR DESCRIPTION
Added support for the `full_count` parameter:
```
  :param full_count: This parameter applies only to queries with LIMIT
      clauses. If set to True, the number of matched documents before
      the last LIMIT clause executed is included in teh cursor. This is
      similar to MySQL SQL_CALC_FOUND_ROWS hint. Using this disables a
      few LIMIT optimizations and may lead to a longer query execution.
```