### PR TITLE
Applied Schema Caching Fix | Canidate V0.7.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-Versoin 0.6.2
+Versoin 0.7.1
 -------------
 
 Merging PR from @chris-green with thanks.

--- a/README.rst
+++ b/README.rst
@@ -448,7 +448,7 @@ Now it's time to create the graph. Note that we don't need to create the collect
     db.create_graph(uni_graph)
 
 
-Now the graph and all it's collections have been created, we can verify their existence:
+Now the graph and all its collections have been created, we can verify their existence:
 
 .. code-block:: python
 

--- a/arango_orm/query.py
+++ b/arango_orm/query.py
@@ -41,6 +41,16 @@ class Query(object):
 
         return next(results)
 
+    def full_count(self):
+        "Return collection full count"
+
+        aql = self._make_aql()
+
+        aql += "\n RETURN rec"
+
+        cursor = self._db.aql.execute(aql, bind_vars=self._bind_vars, full_count=True)
+        return cursor.statistics()['fullCount']
+
     def by_key(self, key, **kwargs):
         "Return a single document using it's key"
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requires = ["six", "python-arango>=4.0", "marshmallow"]
 setup(
     name="arango-orm",
-    version="0.6.2",
+    version="0.7.1",
     description="A SQLAlchemy like ORM implementation for arangodb",
     long_description=(
         "A SQLAlchemy like ORM implementation using "

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -266,3 +266,11 @@ class TestQuery(TestBase):
         db.query(Car).delete()
 
         assert 0 == db.query(Car).count()
+
+    def test_19_get_full_count(self):
+
+        db = self._get_db_obj()
+
+        count_1 = db.query(Person).limit(1).full_count()
+
+        assert count_1 == 2


### PR DESCRIPTION
- use python `__{class.__name__}` prefix to store schema caches similar to the python double underscore, name mangling approach.
- added recache option in schema to allow changing schema [ schema(...,recache:bool=False) ]

This PR should address these issues, while preserving the memory overflow fix of 0.7.0
#120
#115
#114

@kashifpk I did run these through the testing system and found that all tests passed. I think it might be worthwhile to check the relation's schema since I don't really use those in my application.

@overbost you may find this useful for your issues.