### PR TITLE
Fix schema cache and add features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,13 @@
 CHANGES
 =======
 
-Versoin 0.6.2
+Version 0.7.1
+-------------
+
+- Add Collection.get_schema_class(), schema() return instance instead
+- Fix Collection.schema(). Marshmallow schema is recreated in case of class inheritation.
+
+Version 0.6.2
 -------------
 
 Merging PR from @chris-green with thanks.

--- a/README.rst
+++ b/README.rst
@@ -448,7 +448,7 @@ Now it's time to create the graph. Note that we don't need to create the collect
     db.create_graph(uni_graph)
 
 
-Now the graph and all its collections have been created, we can verify their existence:
+Now the graph and all it's collections have been created, we can verify their existence:
 
 .. code-block:: python
 

--- a/arango_orm/connection_pool.py
+++ b/arango_orm/connection_pool.py
@@ -70,6 +70,10 @@ class ConnectionPool(object):
         """Database.delete wrapper."""
         return self._db.delete(entity, **kwargs)
 
+    def bulk_delete(self, entity_list, **kwargs):
+        """Database.bulk_delete wrapper."""
+        return self._db.bulk_delete(entity_list, **kwargs)
+
     def update(self, entity, only_dirty=False, **kwargs):
         """Database.update wrapper."""
         return self._db.update(entity, only_dirty=only_dirty, **kwargs)

--- a/arango_orm/database.py
+++ b/arango_orm/database.py
@@ -209,6 +209,13 @@ class Database(ArangoDatabase):
         dispatch(entity, "post_delete", db=self, result=res)
         return res
 
+    def bulk_delete(self, entity_list, **kwargs):
+        '''Bulk delete utility, based on delete method. Return a list of results.'''
+        res = []
+        for entity in entity_list:
+            res.append(self.delete(entity, **kwargs))
+        return res    
+
     def update(self, entity, only_dirty=False, **kwargs):
         "Update given document"
         collection = self._db.collection(entity.__collection__)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requires = ["six", "python-arango>=4.0", "marshmallow"]
 setup(
     name="arango-orm",
-    version="0.6.2",
+    version="0.7.1",
     description="A SQLAlchemy like ORM implementation for arangodb",
     long_description=(
         "A SQLAlchemy like ORM implementation using "

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -252,3 +252,16 @@ class TestCollection(TestBase):
         knitting = new_person.hobby[1]
         self.assertEqual(knitting.name, "Knitting")
         self.assertEqual(knitting.type, "Relaxing")
+
+    def test_14_class_inheritance(self):
+        class SuperCar(Car):
+            __collection__ = "supercar"
+
+        #shitty_audi = Car(make="Audi", model="RS4", year="2022")
+
+        bmw_m3_e92 = SuperCar._load({"make": "BMW", "model": "M3 E92", "year":"2009"})
+
+        print(SuperCar._cls_schema.__name__)
+
+        self.assertEqual(bmw_m3_e92.__collection__, "supercar")
+        

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -462,3 +462,32 @@ class TestDatabase(TestBase):
         self.assertEqual(p_ref2.name, "NB-20")
         self.assertEqual("Wayne John", s1.name)
         self.assertEqual("Parker Lilly", s2.name)
+
+    def test_25_bulk_delete_records(self):
+
+        db = self._get_db_obj()
+
+        count_0 = db.query(Person).count()
+        p = [
+            Person(
+                name="temp0", _key="73", dob=date(year=2016, month=9, day=12)
+            ),
+            Person(
+                name="temp1", _key="74", dob=date(year=2017, month=9, day=12)
+            ),
+            Person(
+                name="temp2", _key="75", dob=date(year=2018, month=9, day=12)
+            ),
+        ]
+        db.bulk_add(p)
+
+        count_1 = db.query(Person).count()
+
+        assert count_1 == count_0 + len(p)
+
+        db.bulk_delete(p)
+
+        count_2 = db.query(Person).count()
+
+        assert count_2 == count_0
+

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -267,6 +267,7 @@ class TestQuery(TestBase):
 
         assert 0 == db.query(Car).count()
 
+
     def test_19_get_full_count(self):
 
         db = self._get_db_obj()


### PR DESCRIPTION
- Collection.schema is fixed, schema is regenerated in case of class inheritance
- Collection.get_schema_class method is added, return class instead of instance. Used by schema method too
- Query.full_count added (by SoundsSerious)
- Database.bulk_delete added. Just a wrapper to delete a loop of collections/relation

Test completed successfully 

I'm sorry if i made some mistake, it's my first PR LOL